### PR TITLE
chore: add commit message guidelines and enforce linting rules

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [2, "always", ["feat", "fix", "chore", "docs", "style", "refactor", "perf", "test", "ci"]],
+    "scope-empty": [2, "never"]
+  }
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Summary
+
+Provide a one-line summary of the change.
+
+## Changes
+
+- What changed and why.
+
+## Testing
+
+- How was this tested? Include commands or steps to reproduce.
+
+## Commit message checklist
+
+- Use Conventional Commits: `type(scope): subject`.
+- Examples: `feat(parser): add EXPLAIN support`, `fix(ollama): handle timeouts`, `chore(release): bump VERSION to v0.1.7`
+
+## Release notes
+
+- Short description for release notes (if applicable).
+<!--
+🚨 Branch Naming Convention:
+- Features: feature/{component}-{desc}
+- Bugfix:  bugfix/{issue-number}-{desc}
+- Release: release/v{major}.{minor}.{patch}
+- Hotfix:  hotfix/v{version}-{desc}
+-->
+
+**Checklist:**
+- [ ] My branch name follows the convention.
+- [ ] My commit messages use Conventional Commits.

--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,17 @@
+name: Branch Name Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if ! [[ "$BRANCH" =~ ^(feature\/[a-zA-Z0-9\-]+|bugfix\/[0-9]+-[a-zA-Z0-9\-]+|release\/v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]+)?|hotfix\/v[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z0-9\-]+)$ ]]; then
+            echo "::error file=.github/workflows/branch-name-check.yml::Branch name '$BRANCH' does not match naming convention!"
+            exit 1
+          fi

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,62 @@
+name: Commitlint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - develop
+      - 'release/**'
+      - 'feature/**'
+
+jobs:
+  commitlint:
+    name: Commit message lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # need full history to lint commits in push/PR
+          fetch-depth: 0
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Collect commitlint output and comment (PRs only)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const execSync = require('child_process').execSync;
+            try {
+              // run commitlint for the PR range
+              const sha = process.env.GITHUB_SHA;
+              const head = sha;
+              const base = process.env.GITHUB_BASE_REF || 'main';
+              // Use commitlint CLI via npx to check commits between base..head
+              const cmd = `npx --yes @commitlint/cli --from=${base} --to=${head}`;
+              let out = '';
+              try {
+                out = execSync(cmd, { encoding: 'utf8' });
+              } catch (err) {
+                // commitlint exits non-zero on failures; capture stdout/stderr
+                out = (err.stdout || '') + '\n' + (err.stderr || '');
+              }
+              if (out && out.trim().length > 0) {
+                const prNumber = context.payload.pull_request.number;
+                const body = `Commit message lint results for this PR:\n\n\`\`\`\n${out}\n\`\`\`\n\nPlease update offending commit messages to match Conventional Commits. Examples:\n- feat(scope): add new analyzer\n- fix(parser): handle nested queries\n- chore(release): bump VERSION to v0.1.7`;
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body
+                });
+              }
+            } catch (e) {
+              console.log('Error while running commitlint comment step:', e);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,22 @@ We welcome contributions of all kinds, including bug reports, feature requests, 
 - Use the [Conventional Commits](https://www.conventionalcommits.org/) style when possible
 - Example: `fix(parser): handle multiline queries in log parser`
 
+### Commit message guidelines
+
+- Structure: `type(scope): short description` (e.g. `feat(parser): add EXPLAIN support`)
+- Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `ci`
+- Include a scope when relevant (e.g. `parser`, `llm`, `helm`)
+- Use imperative, present tense: `fix`, not `fixed` or `fixes`
+- For release bumps: `chore(release): bump VERSION to vX.Y.Z`
+
+Our CI enforces commit message format; if commits fail linting, update them with interactive rebase:
+
+```bash
+git rebase -i HEAD~5
+# edit commit messages
+git push --force-with-lease
+```
+
 ## Pull Request Review Process
 
 - All PRs are reviewed by maintainers


### PR DESCRIPTION
This pull request introduces new standards and automation for branch naming and commit message formatting, aiming to improve consistency and enforce best practices across the codebase. The main changes include adding CI workflows to check branch names and lint commit messages, updating documentation and templates to guide contributors, and configuring commitlint rules.

**Commit message and branch naming enforcement:**

* Added `.github/workflows/commitlint.yml` to automatically lint commit messages in PRs and pushes, with CI feedback and PR comments for non-compliant messages.
* Created `.commitlintrc.json` to specify allowed commit types and require non-empty scopes, enforcing the Conventional Commits standard.

**Branch naming standardization:**

* Added `.github/workflows/branch-name-check.yml` to validate branch names against project conventions during PR events, failing CI on invalid names.

**Contributor guidance and templates:**

* Updated `CONTRIBUTING.md` to include detailed commit message guidelines, examples, and instructions for fixing commit messages if CI fails.
* Added a new PR template `.github/PULL_REQUEST_TEMPLATE.md` with sections for summary, changes, testing, and checklists for branch and commit standards.